### PR TITLE
Update runtime to 6.9, update py-sdl2

### DIFF
--- a/net.sourceforge.m64py.M64Py.yml
+++ b/net.sourceforge.m64py.M64Py.yml
@@ -145,13 +145,18 @@ modules:
 
   - name: unrar
     buildsystem: autotools
-    no-autogen: true
+    post-install:
+      - ln -s /app/bin/unrar-free /app/bin/unrar
     make-install-args:
       - DESTDIR=/app
     sources:
       - type: archive
-        url: https://www.rarlab.com/rar/unrarsrc-7.0.9.tar.gz
-        sha256: 505c13f9e4c54c01546f2e29b2fcc2d7fabc856a060b81e5cdfe6012a9198326
+        url: https://gitlab.com/bgermann/unrar-free/-/archive/0.3.2/unrar-free-0.3.2.tar.gz
+        sha256: 1dd3a090d44e4ca8dfb052516fbf05ca613e7223c3645043110dafb01cd68a78
+      - type: script
+        dest-filename: autogen.sh
+        commands:
+          - autoreconf -vfi
 
   - name: pylzma
     buildsystem: simple

--- a/net.sourceforge.m64py.M64Py.yml
+++ b/net.sourceforge.m64py.M64Py.yml
@@ -175,8 +175,8 @@ modules:
       - python3 -m pip install --no-index --prefix=/app --no-build-isolation .
     sources:
       - type: archive
-        url: https://github.com/py-sdl/py-sdl2/releases/download/0.9.16/PySDL2-0.9.16.tar.gz
-        sha256: 1027406badbecdd30fe56e800a5a76ad7d7271a3aec0b7acf780ee26a00f2d40
+        url: https://github.com/py-sdl/py-sdl2/archive/refs/tags/0.9.17.tar.gz
+        sha256: f3ae2232075271d997502f6c90a0c41778296248d86b6780623dc3d88efdde0f
 
   - name: m64py
     buildsystem: simple

--- a/net.sourceforge.m64py.M64Py.yml
+++ b/net.sourceforge.m64py.M64Py.yml
@@ -1,9 +1,9 @@
 app-id: net.sourceforge.m64py.M64Py
 runtime: org.kde.Platform
-runtime-version: '6.7'
+runtime-version: '6.9'
 sdk: org.kde.Sdk
 base: com.riverbankcomputing.PyQt.BaseApp
-base-version: '6.7'
+base-version: '6.9'
 
 command: m64py
 

--- a/net.sourceforge.m64py.M64Py.yml
+++ b/net.sourceforge.m64py.M64Py.yml
@@ -145,18 +145,13 @@ modules:
 
   - name: unrar
     buildsystem: autotools
-    post-install:
-      - ln -s /app/bin/unrar-free /app/bin/unrar
+    no-autogen: true
     make-install-args:
       - DESTDIR=/app
     sources:
       - type: archive
-        url: https://gitlab.com/bgermann/unrar-free/-/archive/0.3.2/unrar-free-0.3.2.tar.gz
-        sha256: 1dd3a090d44e4ca8dfb052516fbf05ca613e7223c3645043110dafb01cd68a78
-      - type: script
-        dest-filename: autogen.sh
-        commands:
-          - autoreconf -vfi
+        url: https://www.rarlab.com/rar/unrarsrc-7.0.9.tar.gz
+        sha256: 505c13f9e4c54c01546f2e29b2fcc2d7fabc856a060b81e5cdfe6012a9198326
 
   - name: pylzma
     buildsystem: simple


### PR DESCRIPTION
~~`unrar-free` is a free alternative to the proprietary `unrar`~~ but does not support all necessary features